### PR TITLE
Ovn ironic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+cloud-and-creds.sh
+*.img
+ironic-python-agent.*

--- a/config-maas.sh
+++ b/config-maas.sh
@@ -2,7 +2,7 @@
 
 #set -e
 
-IMAGE_SERIES="bionic focal jammy"
+IMAGE_SERIES="jammy"
 PROFILE=admin
 API_KEY_FILE=$HOME/admin-api-key
 KVM_INTERNAL_IP=10.0.0.1

--- a/ironic-bundle.yaml
+++ b/ironic-bundle.yaml
@@ -1,5 +1,5 @@
 variables:
-  openstack-origin: &openstack-origin distro
+  openstack-origin: &openstack-origin cloud:jammy-bobcat
   data-port: &data-port br-ex:ens4 br-deployment:ens5
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
@@ -7,9 +7,10 @@ variables:
   expected-mon-count: &expected-mon-count 3
   oam-space: &oam-space main
   data-space: &data-space data
-  openstack-channel: &openstack-channel ussuri/edge
-  ceph-channel: &ceph-channel octopus/edge
-  series: &series focal
+  openstack-channel: &openstack-channel latest/edge
+  ceph-channel: &ceph-channel latest/edge
+  ovn-channel: &ovn-channel 23.09/candidate
+  series: &series jammy
 
 machines:
   "1":
@@ -27,9 +28,9 @@ relations:
   - ironic-api
 - - neutron-ironic-agent:identity-credentials
   - keystone
-- - neutron-ironic-agent
+- - neutron-api-plugin-ovn
   - neutron-api
-- - neutron-openvswitch
+- - neutron-ironic-agent
   - neutron-api
 - - ironic-api:amqp
   - rabbitmq-server:amqp
@@ -55,8 +56,6 @@ relations:
   - keystone
 - - nova-ironic
   - nova-cloud-controller
-- - neutron-gateway:amqp
-  - rabbitmq-server:amqp
 - - keystone:shared-db
   - keystone-mysql-router:shared-db
 - - keystone-mysql-router:db-router
@@ -73,8 +72,18 @@ relations:
   - mysql-innodb-cluster:db-router
 - - neutron-api:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - ovn-chassis:nova-compute
+  - nova-ironic:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - neutron-api-plugin-ovn:certificates
+  - vault:certificates
 - - glance:shared-db
   - glance-mysql-router:shared-db
 - - glance-mysql-router:db-router
@@ -85,8 +94,6 @@ relations:
   - glance:image-service
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
-- - nova-cloud-controller:quantum-network-service
-  - neutron-gateway:quantum-network-service
 - - openstack-dashboard:identity-service
   - keystone:identity-service
 - - openstack-dashboard:shared-db
@@ -111,10 +118,6 @@ relations:
   - cinder-mysql-router:shared-db
 - - cinder-mysql-router:db-router
   - mysql-innodb-cluster:db-router
-- - ntp:juju-info
-  - neutron-gateway
-- - ntp:juju-info
-  - neutron-gateway:juju-info
 - - placement
   - placement-mysql-router:shared-db
 - - placement-mysql-router:db-router
@@ -300,26 +303,33 @@ applications:
       worker-multiplier: *worker-multiplier
     to:
       - "lxd:4"
-  neutron-gateway:
-    annotations:
-      gui-x: '0'
-      gui-y: '0'
-    charm: ch:neutron-gateway
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
     channel: *openstack-channel
+    num_units: 0
+  ovn-central:
+    charm: ch:ovn-central
+    channel: *ovn-channel
     comment: SET data-port to match your environment
-    num_units: 1
+    num_units: 3
+    options:
+      ovn-source: *openstack-origin
+      source: *openstack-origin
     bindings:
       "": *oam-space
-    #  data: *data-space
-    options:
-      bridge-mappings: physnet1:br-ex physnet2:br-deployment
-      data-port: *data-port
-      openstack-origin: *openstack-origin
-      enable-isolated-metadata: true
-      enable-metadata-network: true
-      worker-multiplier: *worker-multiplier
     to:
-      - 1
+      - "lxd:1"
+      - "lxd:2"
+      - "lxd:3"
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+    num_units: 0
+    options:
+      ovn-bridge-mappings: physnet1:br-ex physnet2:br-deployment
+      bridge-interface-mappings: *data-port
+      prefer-chassis-as-gw: true
+      ovn-source: *openstack-origin
   nova-cloud-controller:
     annotations:
       gui-x: '0'
@@ -347,7 +357,7 @@ applications:
       openstack-origin: *openstack-origin
       virt-type: ironic
     to:
-      - "lxd:3"
+      - 1
   ntp:
     annotations:
       gui-x: '1000'
@@ -416,16 +426,18 @@ applications:
       "": *oam-space
     to:
       - "lxd:2"
-  neutron-openvswitch:
-    charm: ch:neutron-openvswitch
-    channel: *openstack-channel
-    num_units: 0
-    options:
-      bridge-mappings: physnet1:br-ex physnet2:br-deployment
-      data-port: *data-port
   neutron-ironic-agent:
     charm: ch:neutron-api-plugin-ironic
     channel: *openstack-channel
     num_units: 0
     options:
       openstack-origin: *openstack-origin
+  vault:
+    charm: ch:vault
+    channel: latest/edge
+    num_units: 1
+    options:
+      auto-generate-root-ca-cert: true
+      totally-unsecure-auto-unlock: true
+    to:
+      - "lxd:1"

--- a/main.tf
+++ b/main.tf
@@ -36,13 +36,13 @@ variable "maas_nodes_rootfs_size" {
 variable "maas_nodes_vcpu" {
   description = "MAAS nodes number of vcpus"
   type = number
-  default = 2
+  default = 6
 }
 
 variable "maas_nodes_mem" {
   description = "MAAS nodes memory"
   type = string
-  default = "8192"
+  default = "24576"
 }
 
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
-variable "ubuntu_focal_img" {
+variable "ubuntu_jammy_img" {
   type = string
-  default = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+  default = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
 }
 
 variable "num_maas_nodes" {
@@ -94,17 +94,17 @@ resource "libvirt_network" "external_network" {
   dhcp { enabled = true }
 }
 # Defining VM Volume
-resource "libvirt_volume" "ubuntu_focal" {
-  name = "ubuntu-focal.qcow2"
+resource "libvirt_volume" "ubuntu_jammy" {
+  name = "ubuntu-jammy.qcow2"
   pool = "default"
-  source = var.ubuntu_focal_img
+  source = var.ubuntu_jammy_img
   format = "qcow2"
 }
 resource "libvirt_volume" "maas_controller_rootfs" {
   name = "maas-controller.qcow2"
   pool = "default"
   format = "qcow2"
-  base_volume_id = libvirt_volume.ubuntu_focal.id
+  base_volume_id = libvirt_volume.ubuntu_jammy.id
   size = 21474836480  # 20GiB
 }
 
@@ -216,9 +216,9 @@ resource "libvirt_domain" "maas_controller" {
       "echo block until there is a ipxe.cfg available",
       "until wget -O - http://10.0.0.2:5248/ipxe.cfg; do sleep 5;done",
       "echo wait for images to be fully unpacked",
-      # 20.04 is used for commissioning, if a different image is used, then change the URL accordingly
-      "until wget -O /dev/null http://10.0.0.2:5248/images/ubuntu/amd64/ga-20.04/focal/stable/boot-initrd; do sleep 5;done",
-      "until wget -O /dev/null http://10.0.0.2:5248/images/ubuntu/amd64/ga-20.04/focal/stable/boot-kernel; do sleep 5;done",
+      # 22.04 is used for commissioning, if a different image is used, then change the URL accordingly
+      "until wget -O /dev/null http://10.0.0.2:5248/images/ubuntu/amd64/ga-22.04/jammy/stable/boot-initrd; do sleep 5;done",
+      "until wget -O /dev/null http://10.0.0.2:5248/images/ubuntu/amd64/ga-22.04/jammy/stable/boot-kernel; do sleep 5;done",
     ]
   }
 
@@ -616,7 +616,7 @@ if [[ ! -f baremetal-ubuntu-focal.img ]]; then
     wget http://10.245.161.162/swift/v1/images/baremetal-ubuntu-focal.img
 fi
 
-for release in bionic focal
+for release in bionic focal jammy
 do
     glance image-create \
         --store swift \

--- a/main.tf
+++ b/main.tf
@@ -496,8 +496,8 @@ juju add-model ironic
 juju add-space ironic 10.10.0.0/24
 juju add-space main 10.0.0.0/24
 juju deploy ./ironic-bundle.yaml
-juju wait -x ironic-conductor
-juju run-action ironic-conductor/leader set-temp-url-secret --wait
+juju wait-for application ironic-conductor --query='name=="ironic-conductor" && (status=="blocked" || status=="active")' --timeout=90m
+juju run ironic-conductor/leader set-temp-url-secret --wait=2m
 EOF
     when = create
   }
@@ -594,6 +594,9 @@ openstack subnet create \
      deployment
 
 openstack router add subnet ironic-router deployment
+
+deployment_net=$(openstack network show -c id -f value deployment)
+juju config ironic-conductor cleaning-network=$deployment_net provisioning-network=$deployment_net
 EOF
   }
 }

--- a/novarc
+++ b/novarc
@@ -6,12 +6,12 @@ unset _OS_PARAMS
 
 keystone_unit=$(juju status keystone|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
 echo Keystone unit: ${keystone_unit}
-if ! curl -qs `juju run --unit ${keystone_unit} "unit-get private-address"`:5000/v3 | grep 404 ;
+if ! curl -qs `juju exec --unit ${keystone_unit} "unit-get private-address"`:5000/v3 | grep 404 ;
 then
 echo Using keystone v3 api
-export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju run --unit ${keystone_unit} "unit-get private-address"`:5000/v3
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju exec --unit ${keystone_unit} "unit-get private-address"`:5000/v3
 export OS_USERNAME=admin
-export OS_PASSWORD=`juju run --unit keystone/0 leader-get admin_passwd`
+export OS_PASSWORD=`juju exec --unit keystone/0 leader-get admin_passwd`
 export OS_DOMAIN_NAME=admin_domain
 export OS_USER_DOMAIN_NAME=admin_domain
 export OS_PROJECT_DOMAIN_NAME=admin_domain
@@ -23,9 +23,9 @@ export OS_AUTH_VERSION=3
 else
 echo Using keystone v2 api
 export OS_USERNAME=admin
-export OS_PASSWORD=`juju run --unit keystone/0 leader-get admin_passwd`
+export OS_PASSWORD=`juju exec --unit keystone/0 leader-get admin_passwd`
 export OS_TENANT_NAME=admin
 export OS_REGION_NAME=RegionOne
-export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju run --unit ${keystone_unit} "unit-get private-address"`:5000/v2.0
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://`juju exec --unit ${keystone_unit} "unit-get private-address"`:5000/v2.0
 fi
 


### PR DESCRIPTION
Changes the deployment to use OVN as the SDN rather than OVS. Amongst other things, this PR will also switch the deployment to be a Juju 3 compatible deployment.

Note: this requires the changes in [this patch series](https://review.opendev.org/q/topic:%22ironic-support%22) in order for this code to function correctly.